### PR TITLE
styles.nim - Search and replace 32_t = 32 and lxw_formats = lxw_format

### DIFF
--- a/nimlibxlsxwriter.cfg
+++ b/nimlibxlsxwriter.cfg
@@ -104,6 +104,13 @@ append.ef = "\nexport format"
 [shared_strings.nim]
 line
 
+[styles.nim]
+search.32t = "32_t"
+replace.32t = "32"
+
+search.lxwformats = "lxw_formats"
+replace.lxwformats = "lxw_format"
+
 [utility.nim]
 line
 


### PR DESCRIPTION
The `[n.wildcard]` should have taken care of the `32_t`, but this does not happen on my machine.

OS: Linux Arch
Nim: 0.18.0 / 0.18.1 / 0.19.0

Reference: #7 